### PR TITLE
Use GitHub App token for release tracker comments

### DIFF
--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -13,8 +13,6 @@ jobs:
   build:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -20,8 +20,8 @@ jobs:
         with:
           submodules: true
 
-      - name: Generate GitHub App token
-        id: app-token
+      - name: Generate LGTM App token
+        id: lgtm-app-token
         if: |
           github.event.action == 'closed' &&
           github.event.pull_request.merged == true
@@ -38,6 +38,6 @@ jobs:
           github.event.pull_request.merged == true
         env:
           GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.lgtm-app-token.outputs.token }}
         run: |
           ./hack/scripts/update-release-tracker.sh

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -27,6 +27,7 @@ jobs:
           private-key: ${{ secrets.LGTM_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: CHANGELOG
+          permission-pull-requests: write
 
       - name: Update release tracker
         env:

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -22,9 +23,6 @@ jobs:
 
       - name: Generate LGTM App token
         id: lgtm-app-token
-        if: |
-          github.event.action == 'closed' &&
-          github.event.pull_request.merged == true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.LGTM_APP_CLIENT_ID }}
@@ -33,9 +31,6 @@ jobs:
           repositories: CHANGELOG
 
       - name: Update release tracker
-        if: |
-          github.event.action == 'closed' &&
-          github.event.pull_request.merged == true
         env:
           GITHUB_USER: ${{ github.actor }}
           GITHUB_TOKEN: ${{ steps.lgtm-app-token.outputs.token }}

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -29,11 +29,6 @@ jobs:
           git config --global user.email "${GITHUB_USER}@appscode.com"
           git remote set-url origin https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
 
-      - name: Install GitHub CLI
-        run: |
-          curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-          sudo mv bin/hub /usr/local/bin
-
       - name: Generate GitHub App token
         id: app-token
         if: |

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -34,12 +34,24 @@ jobs:
           curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
           sudo mv bin/hub /usr/local/bin
 
+      - name: Generate GitHub App token
+        id: app-token
+        if: |
+          github.event.action == 'closed' &&
+          github.event.pull_request.merged == true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.LGTM_APP_CLIENT_ID }}
+          private-key: ${{ secrets.LGTM_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: CHANGELOG
+
       - name: Update release tracker
         if: |
           github.event.action == 'closed' &&
           github.event.pull_request.merged == true
         env:
           GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           ./hack/scripts/update-release-tracker.sh

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -20,15 +20,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Prepare git
-        env:
-          GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config --global user.name "${GITHUB_USER}"
-          git config --global user.email "${GITHUB_USER}@appscode.com"
-          git remote set-url origin https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-
       - name: Generate GitHub App token
         id: app-token
         if: |

--- a/hack/scripts/update-release-tracker.sh
+++ b/hack/scripts/update-release-tracker.sh
@@ -69,4 +69,4 @@ case $GITHUB_BASE_REF in
         ;;
 esac
 
-hub api "$api_url" -f body="$msg"
+gh api "$api_url" -f body="$msg"


### PR DESCRIPTION
Mirrors kubedb/installer#2284.
- release-tracker.yml: use LGTM GitHub App installation token to post comments on the tracker issue/PR in the CHANGELOG repo.