### PR TITLE
Replace liche with lychee for link checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,11 @@ jobs:
 
       - name: Install link checker
         run: |
-          curl -fsSL -o liche https://github.com/appscodelabs/liche/releases/download/v0.1.0/liche-linux-amd64
-          chmod +x liche
-          sudo mv liche /usr/local/bin/liche
+          curl -fsSL -o lychee.tar.gz https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.2/lychee-x86_64-unknown-linux-gnu.tar.gz
+          tar -xzf lychee.tar.gz --strip-components=1
+          chmod +x lychee
+          sudo mv lychee /usr/local/bin/lychee
+          rm lychee.tar.gz
 
       - name: Install npm packages
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ You need Hugo (extended) installed locally and Node.js for the PostCSS pipeline.
 - `make gen-prod` — clean `public/` and run `hugo --minify --config=config.yaml`. Production build.
 - `make qa` — `make gen` then `firebase use default && firebase deploy` (deploys to QA/staging Firebase project).
 - `make release` — `make gen-prod` then deploy to the production Firebase project.
-- `make check-links` — run `liche` against the built `public/` to verify links.
+- `make check-links` — run `lychee` against the built `public/` to verify links.
 - `make set-version VERSION=v1.2.3` — rewrite `firebase.json` doc-version redirects (used during a release cut).
 - `make set-assets-repo ASSETS_REPO_URL=…` — rewrite `data/config.json` to point at a different assets repo.
 - `make hugo-tools` — fetch the `appscodelabs/hugo-tools` binary into `bin/`. Other targets call this automatically.

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ release: gen-prod
 
 .PHONY: check-links
 check-links:
-	lychee --base http://localhost:1313 --max-concurrency 10 --exclude '^http://localhost:9090$$' 'public/**/*.html'
+	lychee --base-url http://localhost:1313 --max-concurrency 10 --exclude '^http://localhost:9090$$' 'public/**/*.html'
 
 VERSION ?=
 

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ release: gen-prod
 
 .PHONY: check-links
 check-links:
-	liche -r public -d http://localhost:1313 -c 10 -p -l -x '^http://localhost:9090$$'
+	lychee --base http://localhost:1313 --max-concurrency 10 --exclude '^http://localhost:9090$$' 'public/**/*.html'
 
 VERSION ?=
 


### PR DESCRIPTION
Replace the archived `appscodelabs/liche` link checker (last released 2018) with `lycheeverse/lychee` v0.24.2.

- CI installer downloads the lychee release tarball instead of the liche binary.
- Link-check invocation rewritten to lychee flags (`--base`, `--max-concurrency`, `--exclude`) with an explicit file glob.